### PR TITLE
Removed attribute configuration from models

### DIFF
--- a/Tables/FuelType.cs
+++ b/Tables/FuelType.cs
@@ -18,9 +18,6 @@ namespace efCoreSqlLiteInMemory.Tables
         [StringLength(255)]
         public string Bezeichnung { get; set; } = null!;
 
-
-        [ForeignKey("FuelTypeId")]
-        [InverseProperty("FuelType")]
         public virtual ICollection<MotorArt> MotorArt { get; set; }
     }
 }

--- a/Tables/MotorArt.cs
+++ b/Tables/MotorArt.cs
@@ -16,12 +16,8 @@ namespace efCoreSqlLiteInMemory.Tables
         public int MotorArtId { get; set; }
         [StringLength(255)]
 
-        
-        [ForeignKey("MotorArtId")]
-        [InverseProperty("MotorArt")]
         public virtual ICollection<FuelType> FuelType { get; set; }
-        [ForeignKey("MotorArtId")]
-        [InverseProperty("MotorArt")]
+
         public virtual ICollection<MotorBauart> MotorBauArt { get; set; }
     }
 }

--- a/Tables/MotorBauart.cs
+++ b/Tables/MotorBauart.cs
@@ -14,8 +14,6 @@ namespace efCoreSqlLiteInMemory.Tables
         [Key]
         public int MotorBauartId { get; set; }
         
-        [ForeignKey("MotorBauArtId")]
-        [InverseProperty("MotorBauArt")]
         public virtual ICollection<MotorArt> MotorArt { get; set; }
     }
 }


### PR DESCRIPTION
By removing explicit attribute configuration from the entities, the code now runs as expected. The issue seems to be arising from configuration being applied both by attributes and by `OnModelCreating()`.